### PR TITLE
Add docker-compose.yml for IPFS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -140,3 +140,6 @@ typechain
 cache
 artifacts
 
+#ipfs
+ipfs
+ipfs_staging

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -25,6 +25,6 @@ wallet:
 node:
   interval: 600
   max_txs: 256
-  ipfs_api_url: http://localhost:5001
-  ipfs_gateway_url: http://localhost:8080
-  ipfs_test: false
+  ipfs_api_url: http://ipfs:5001
+  ipfs_gateway_url: http://ipfs:8080
+  ipfs_test: true

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,37 @@
+version: '3.7'
+
+services:
+   ipfs:
+    container_name: ipfs
+    hostname: ipfs
+    image: ipfs/go-ipfs
+    ports:
+      - "8080:8080"
+      - "4001:4001"
+      - "4001:4001/udp"
+      - "5001:5001"
+    volumes:
+      - ./ipfs:/data/ipfs
+      - ./ipfs_staging:/staging
+    restart: always
+    networks:
+      - ipfs-network
+
+   rollup:
+     container_name: rollup
+     hostname: rollup
+     image:  bosagora/rollup-server:v1.0.0
+     ports:
+       - "3000:3000"
+     volumes:
+       - "./config/:/rollup/config/"
+       - "./env/:/rollup/env/"
+       - "./keystore/:/rollup/keystore/"
+       - "./logs/:/rollup/logs/"
+     restart: always
+     networks:
+       - ipfs-network
+
+networks:
+  ipfs-network:
+    driver: bridge


### PR DESCRIPTION
도커이미지 IPFS와 Rollup-Server를 사용할 수 있는 docker-compose.yml을 추가합니다.
IPFS는 다음 폴더를 사용합니다.
  ipfs/
  ipfs_staging

rollup은 다음 폴더를 사용합니다.
  config/
  env/
  keystore/
  logs/