### PR TITLE
Update on delivery and use of Storage objects

### DIFF
--- a/src/service/scheduler/TransactionPool.ts
+++ b/src/service/scheduler/TransactionPool.ts
@@ -8,14 +8,20 @@
  *       MIT License. See LICENSE for details.
  */
 
+import { logger } from "../common/Logger";
 import { DBTransaction, RollupStorage } from "../storage/RollupStorage";
 
 export class TransactionPool {
     private _storage: RollupStorage | undefined;
 
     get storage(): RollupStorage {
-        return this._storage as RollupStorage;
+        if (this._storage !== undefined) return this._storage;
+        else {
+            logger.error("Storage is not ready yet.");
+            process.exit(1);
+        }
     }
+
     set storage(storage) {
         this._storage = storage;
     }


### PR DESCRIPTION
1. 내부 맴버로 사용된 storage가 undefined 일 때는 프로세스를 종료하도록 했습니다. 이경우는 처음부터 코드가 잘못된 것으로 판단합니다.
2. Node 클래스에 storage를 추가합니다.