### PR TITLE
[Router] Remove rule that user_id is an address

### DIFF
--- a/src/service/routers/RollupRouter.ts
+++ b/src/service/routers/RollupRouter.ts
@@ -124,8 +124,6 @@ export class RollupRouter {
                     .not()
                     .isEmpty()
                     .withMessage("user_id is a required value")
-                    .isEthereumAddress()
-                    .withMessage("user_id is not wallet address type")
                     .bail(),
                 body("state")
                     .exists()


### PR DESCRIPTION
user_id 는 이더리움의 주소가 아니라 그냥 문자열입니다.