### PR TITLE
[SendBlock] Initialize nonce when an error occurs

### DIFF
--- a/src/service/scheduler/SendBlock.ts
+++ b/src/service/scheduler/SendBlock.ts
@@ -144,12 +144,24 @@ export class SendBlock extends Scheduler {
             }
 
             if (data) {
-                await this._rollup
-                    .connect(this.managerSigner)
-                    .add(data.height, data.cur_block, data.prev_block, data.merkle_root, data.timestamp, data.CID)
-                    .then(() => {
-                        logger.info(`Successful in adding blocks to the blockchain. Height: ${data.height}`);
-                    });
+                try {
+                    await this._rollup
+                        .connect(this.managerSigner)
+                        .add(
+                            data.height,
+                            data.cur_block,
+                            data.prev_block,
+                            data.merkle_root,
+                            data.timestamp,
+                            data.CID
+                        )
+                        .then(() => {
+                            logger.info(`Successful in adding blocks to the blockchain. Height: ${data.height}`);
+                        });
+                } catch (err) {
+                    const signer = this.managerSigner as NonceManager;
+                    signer.setTransactionCount(await signer.getTransactionCount());
+                }
             } else {
                 logger.info(`This block is not ready.`);
             }


### PR DESCRIPTION
스마트컨트랙트에 블록정보를 저장하던중 오류가 발생하면
해당 트랜잭션은 무시되므로  해당 계정의 nonce를 초기화 해서, 다음의 스마트컨트랙트의 호출이 원활하게 진행될 수 있도록 해줍니다