### PR TITLE
[SendBlock] Add `send_interval` to config

### DIFF
--- a/config/config.example.yaml
+++ b/config/config.example.yaml
@@ -21,6 +21,7 @@ logging:
 node:
   interval: 600
   max_txs: 256
+  send_interval: 14
   ipfs_api_url: https://api-ipfs.bosagora.info
   ipfs_gateway_url: https://ipfs.bosagora.info
   ipfs_test: false

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -21,6 +21,7 @@ logging:
 node:
   interval: 600
   max_txs: 256
+  send_interval: 14
   ipfs_api_url: http://ipfs:5001
   ipfs_gateway_url: http://ipfs:8080
   ipfs_test: true

--- a/config/config_test.yaml
+++ b/config/config_test.yaml
@@ -21,6 +21,7 @@ logging:
 node:
   interval: 5
   max_txs: 8
+  send_interval: 1
   ipfs_api_url: http://localhost:5001
   ipfs_gateway_url: http://localhost:8080
   ipfs_test: true

--- a/src/service/common/Config.ts
+++ b/src/service/common/Config.ts
@@ -287,6 +287,7 @@ export class LoggingConfig implements ILoggingConfig {
 export class NodeConfig implements INodeConfig {
     public interval: number;
     public max_txs: number;
+    public send_interval: number;
     public ipfs_api_url: string;
     public ipfs_gateway_url: string;
     public ipfs_test: boolean;
@@ -299,6 +300,7 @@ export class NodeConfig implements INodeConfig {
 
         this.interval = defaults.interval;
         this.max_txs = defaults.max_txs;
+        this.send_interval = defaults.send_interval;
         this.ipfs_api_url = defaults.ipfs_api_url;
         this.ipfs_gateway_url = defaults.ipfs_gateway_url;
         this.ipfs_test = defaults.ipfs_test;
@@ -311,6 +313,7 @@ export class NodeConfig implements INodeConfig {
         return {
             interval: 600,
             max_txs: 128,
+            send_interval: 14,
             ipfs_api_url: "https://api-ipfs.bosagora.info",
             ipfs_gateway_url: "https://ipfs.bosagora.info",
             ipfs_test: true,
@@ -324,6 +327,7 @@ export class NodeConfig implements INodeConfig {
     public readFromObject(config: INodeConfig) {
         if (config.interval !== undefined) this.interval = config.interval;
         if (config.max_txs !== undefined) this.max_txs = config.max_txs;
+        if (config.send_interval !== undefined) this.send_interval = config.send_interval;
         if (config.ipfs_api_url !== undefined) this.ipfs_api_url = config.ipfs_api_url;
         if (config.ipfs_gateway_url !== undefined) this.ipfs_gateway_url = config.ipfs_gateway_url;
         if (config.ipfs_test !== undefined) this.ipfs_test = config.ipfs_test;
@@ -368,6 +372,7 @@ export interface ILoggingConfig {
 export interface INodeConfig {
     interval: number;
     max_txs: number;
+    send_interval: number;
     ipfs_api_url: string;
     ipfs_gateway_url: string;
     ipfs_test: boolean;

--- a/src/service/scheduler/SendBlock.ts
+++ b/src/service/scheduler/SendBlock.ts
@@ -11,6 +11,7 @@
 import { NonceManager } from "@ethersproject/experimental";
 import { Signer, Wallet } from "ethers";
 import { ethers } from "hardhat";
+import { Utils } from "rollup-pm-sdk";
 import { RollUp } from "../../../typechain-types";
 import { Scheduler } from "../../modules";
 import { Config } from "../common/Config";
@@ -45,12 +46,19 @@ export class SendBlock extends Scheduler {
     private _managerSigner: NonceManager | undefined;
 
     /**
+     * This is the timestamp when the previous block was created
+     */
+    private old_time_stamp: number;
+
+    /**
      * Constructor
      * @param interval
      */
-    constructor(interval: number = 14) {
+    constructor(interval: number = 1) {
         // interval second
         super(interval);
+
+        this.old_time_stamp = Utils.getTimeStamp();
     }
 
     /**
@@ -107,7 +115,15 @@ export class SendBlock extends Scheduler {
      * @protected
      */
     protected override async work() {
+        const new_time_stamp = Utils.getTimeStamp();
         try {
+            const old_period = Math.floor(this.old_time_stamp / this.config.node.send_interval);
+            const new_period = Math.floor(new_time_stamp / this.config.node.send_interval);
+
+            if (old_period === new_period) return;
+
+            this.old_time_stamp = new_time_stamp;
+
             if (this._rollup === undefined) {
                 const contractFactory = await ethers.getContractFactory("RollUp");
                 this._rollup = contractFactory.attach(this.config.contracts.rollup_address) as RollUp;
@@ -144,14 +160,7 @@ export class SendBlock extends Scheduler {
                 try {
                     await this._rollup
                         .connect(this.managerSigner)
-                        .add(
-                            data.height,
-                            data.cur_block,
-                            data.prev_block,
-                            data.merkle_root,
-                            data.timestamp,
-                            data.CID
-                        )
+                        .add(data.height, data.cur_block, data.prev_block, data.merkle_root, data.timestamp, data.CID)
                         .then(() => {
                             logger.info(`Successful in adding blocks to the blockchain. Height: ${data.height}`);
                         });

--- a/test/service/Config.test.ts
+++ b/test/service/Config.test.ts
@@ -20,6 +20,7 @@ describe("Test of Config", () => {
 
         assert.strictEqual(config.node.interval, 10);
         assert.strictEqual(config.node.max_txs, 8);
+        assert.strictEqual(config.node.send_interval, 12);
 
         assert.strictEqual(config.node.ipfs_api_url, "http://localhost:5001");
         assert.strictEqual(config.node.ipfs_gateway_url, "http://localhost:8080");

--- a/test/service/config.test.yaml
+++ b/test/service/config.test.yaml
@@ -9,6 +9,7 @@ logging:
 node:
     interval: 10
     max_txs: 8
+    send_interval: 12
     ipfs_api_url: http://localhost:5001
     ipfs_gateway_url: http://localhost:8080
     ipfs_test: true


### PR DESCRIPTION
Scheduler 의 interval은 1초로 고정하고,
별도의 interval을 두어 클래스 Node와 일관성을 유지했습니다.

다음 PR에서 생성자에서 interval을 변경할 수 없고 1초로 고정할 계획입니다. Scheduler.Interval은 사용하지 않을 계획입니다.