### PR TITLE
Change variable type of amount in Transaction to BigNumber

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -56,7 +56,7 @@
                 "prettier-plugin-solidity": "^1.0.0",
                 "prompt": "^1.3.0",
                 "reflect-metadata": "^0.1.13",
-                "rollup-pm-sdk": "^1.0.1",
+                "rollup-pm-sdk": "^1.0.2",
                 "smart-buffer": "^4.1.0",
                 "solidity-coverage": "^0.8.2",
                 "sqlite3": "^5.1.2",
@@ -19250,12 +19250,12 @@
             }
         },
         "node_modules/rollup-pm-sdk": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/rollup-pm-sdk/-/rollup-pm-sdk-1.0.1.tgz",
-            "integrity": "sha512-KOoqRgykZYJAbtJrYoTFc9DRi3TVQdl+hnlVpYnhA6jX/8miyD4V8E0FM8haVQSbRKXsqGxDRpqt7bDw/h2OxA==",
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/rollup-pm-sdk/-/rollup-pm-sdk-1.0.2.tgz",
+            "integrity": "sha512-BfDtswo90k1mozgxztjmp1DgGo+YSqz32S60/T/PhMQJ9RRAGyKB0jg/wF0nRkiR5PAcyjmZ/zWyNgycxTdmlQ==",
             "dependencies": {
                 "ajv": "^6.12.6",
-                "ethers": "^5.7.2",
+                "ethers": "^5.6.9",
                 "smart-buffer": "^4.1.0",
                 "urijs": "^1.19.7"
             }
@@ -37603,12 +37603,12 @@
             }
         },
         "rollup-pm-sdk": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/rollup-pm-sdk/-/rollup-pm-sdk-1.0.1.tgz",
-            "integrity": "sha512-KOoqRgykZYJAbtJrYoTFc9DRi3TVQdl+hnlVpYnhA6jX/8miyD4V8E0FM8haVQSbRKXsqGxDRpqt7bDw/h2OxA==",
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/rollup-pm-sdk/-/rollup-pm-sdk-1.0.2.tgz",
+            "integrity": "sha512-BfDtswo90k1mozgxztjmp1DgGo+YSqz32S60/T/PhMQJ9RRAGyKB0jg/wF0nRkiR5PAcyjmZ/zWyNgycxTdmlQ==",
             "requires": {
                 "ajv": "^6.12.6",
-                "ethers": "^5.7.2",
+                "ethers": "^5.6.9",
                 "smart-buffer": "^4.1.0",
                 "urijs": "^1.19.7"
             }

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
         "debug:Storage": "NODE_ENV=test node_modules/.bin/hardhat test test/service/Storage.test.ts",
         "debug:TransactionPool": "NODE_ENV=test node_modules/.bin/hardhat test test/blockchain/TransactionPool.test.ts",
         "debug:Node": "NODE_ENV=test node_modules/.bin/hardhat test test/blockchain/Node.test.ts",
+        "debug:Router": "NODE_ENV=test node_modules/.bin/hardhat test test/service/RollupRouter.test.ts",
         "debug:Server": "NODE_ENV=test node_modules/.bin/hardhat test test/service/RollupServer.test.ts"
     },
     "repository": {
@@ -83,7 +84,7 @@
         "prettier-plugin-solidity": "^1.0.0",
         "prompt": "^1.3.0",
         "reflect-metadata": "^0.1.13",
-        "rollup-pm-sdk": "^1.0.1",
+        "rollup-pm-sdk": "^1.0.2",
         "smart-buffer": "^4.1.0",
         "solidity-coverage": "^0.8.2",
         "sqlite3": "^5.1.2",

--- a/src/service/routers/RollupRouter.ts
+++ b/src/service/routers/RollupRouter.ts
@@ -11,6 +11,7 @@
 import express from "express";
 import { body, validationResult } from "express-validator";
 
+import { BigNumber } from "ethers";
 import { Transaction } from "rollup-pm-sdk";
 import { WebService } from "../../modules/service/WebService";
 import { Config } from "../common/Config";
@@ -202,7 +203,7 @@ export class RollupRouter {
                 req.body.trade_id,
                 req.body.user_id,
                 req.body.state,
-                BigInt(req.body.amount),
+                BigNumber.from(req.body.amount),
                 req.body.timestamp,
                 req.body.exchange_user_id,
                 req.body.exchange_id,

--- a/src/service/storage/RollupStorage.ts
+++ b/src/service/storage/RollupStorage.ts
@@ -8,6 +8,7 @@
  *       MIT License. See LICENSE for details.
  */
 
+import { BigNumber } from "ethers";
 import { Block, BlockHeader, Hash, hashFull, Transaction } from "rollup-pm-sdk";
 import { Storage } from "../../modules/storage/Storage";
 import { IDatabaseConfig } from "../common/Config";
@@ -174,7 +175,7 @@ export class DBTransaction {
         trade_id: string,
         user_id: string,
         state: string,
-        amount: bigint,
+        amount: BigNumber,
         timestamp: number,
         exchange_user_id: string,
         exchange_id: string,
@@ -208,7 +209,7 @@ export class DBTransaction {
                     row.trade_id,
                     row.user_id,
                     row.state,
-                    BigInt(row.amount),
+                    BigNumber.from(row.amount),
                     row.timestamp,
                     row.exchange_user_id,
                     row.exchange_id,

--- a/test/blockchain/Node.test.ts
+++ b/test/blockchain/Node.test.ts
@@ -8,7 +8,7 @@
  *       MIT License. See LICENSE for details.
  */
 
-import { Wallet } from "ethers";
+import { BigNumber, Wallet } from "ethers";
 import { waffle } from "hardhat";
 
 import { Block, Hash, Transaction, Utils } from "rollup-pm-sdk";
@@ -77,7 +77,7 @@ describe("Test of Node", function () {
                     (12345670 + idx).toString(),
                     "0x064c9Fc53d5936792845ca58778a52317fCf47F2",
                     "0",
-                    BigInt(idx + 1),
+                    BigNumber.from(idx + 1),
                     Utils.getTimeStamp(),
                     "997DE626B2D417F0361D61C09EB907A57226DB5B",
                     "a5c19fed89739383"

--- a/test/blockchain/TransactionPool.test.ts
+++ b/test/blockchain/TransactionPool.test.ts
@@ -9,6 +9,7 @@
  */
 
 import * as assert from "assert";
+import { BigNumber } from "ethers";
 import path from "path";
 import { Transaction, Utils } from "rollup-pm-sdk";
 import { Config } from "../../src/service/common/Config";
@@ -66,7 +67,7 @@ describe("TransactionPool", () => {
                     "transaction_" + index,
                     "0x064c9Fc53d5936792845ca58778a52317fCf47F2",
                     m,
-                    10000n,
+                    BigNumber.from(10000),
                     Utils.getTimeStamp(),
                     "",
                     ""
@@ -92,7 +93,7 @@ describe("TransactionPool", () => {
             assert.strictEqual(tx[0].trade_id, txs[idx].trade_id);
             assert.strictEqual(tx[0].user_id, txs[idx].user_id);
             assert.strictEqual(tx[0].state, txs[idx].state);
-            assert.strictEqual(tx[0].amount, txs[idx].amount.toString());
+            assert.strictEqual(tx[0].amount.toString(), txs[idx].amount.toString());
             assert.strictEqual(tx[0].timestamp, txs[idx].timestamp);
             assert.strictEqual(tx[0].exchange_user_id, txs[idx].exchange_user_id);
             assert.strictEqual(tx[0].exchange_id, txs[idx].exchange_id);

--- a/test/service/RollupRouter.test.ts
+++ b/test/service/RollupRouter.test.ts
@@ -4,9 +4,9 @@ import chai, { expect } from "chai";
 import chaiHttp from "chai-http";
 
 import * as assert from "assert";
-import { Wallet } from "ethers";
+import { BigNumber, Wallet } from "ethers";
 import * as path from "path";
-import { Transaction } from "rollup-pm-sdk";
+import { ITransaction, Transaction } from "rollup-pm-sdk";
 import { URL } from "url";
 import { RollupServer } from "../../src/service/RollupServer";
 import { DBTransaction, RollupStorage } from "../../src/service/storage/RollupStorage";
@@ -47,20 +47,24 @@ describe("Test of Rollup Router", () => {
         await rollupServer.stop();
     });
 
-    context("Rollup API Call Test", () => {
+    context("Rollup API Call Test", async () => {
         const token: string = "9812176e565a007a84c5d2fc4cf842b12eb26dbc7568b4e40fc4f2418f2c8f54";
-        const tx = {
-            trade_id: "123456789",
-            user_id: "0x064c9Fc53d5936792845ca58778a52317fCf47F2",
-            state: "0",
-            amount: "12300",
-            timestamp: 1668044556,
-            exchange_user_id: "997DE626B2D417F0361D61C09EB907A57226DB5B",
-            exchange_id: "a5c19fed89739383",
-            signer: "0x19dCAc1131Dfa2fdBbf992261d54c03dDE616D75",
-            signature:
-                "0xf3d449722e5e38d0045bdcf538286e44cfc04cde67fa2e7beeca6c3f275b6db723d2cdc4c2cffe1cfa0441f6390975ddeaed6d4bbc5dbd2610e9cae32634f9cc1c",
-        };
+        let tx: ITransaction;
+
+        before("Create Sample Transaction", async () => {
+            const signer = new Wallet("0xf6dda8e03f9dce37c081e5d178c1fda2ebdb90b5b099de1a555a658270d8c47d");
+            const txObj = new Transaction(
+                "123456789",
+                "0x064c9Fc53d5936792845ca58778a52317fCf47F2",
+                "0",
+                BigNumber.from("12300"),
+                1668044556,
+                "997DE626B2D417F0361D61C09EB907A57226DB5B",
+                "a5c19fed89739383"
+            );
+            await txObj.sign(signer);
+            tx = txObj.toJSON();
+        });
 
         it("Send transaction data to api server", async () => {
             chai.request(serverURL)

--- a/test/service/RollupServer.test.ts
+++ b/test/service/RollupServer.test.ts
@@ -1,7 +1,7 @@
 import { Config } from "../../src/service/common/Config";
 
 import * as assert from "assert";
-import { Wallet } from "ethers";
+import { BigNumber, Wallet } from "ethers";
 import * as path from "path";
 import { Transaction, Utils } from "rollup-pm-sdk";
 import URI from "urijs";
@@ -103,7 +103,7 @@ describe("Test of Rollup Server", function () {
                 "TX" + numTx.toString().padStart(10, "0"),
                 signer.address,
                 "0",
-                10000n,
+                BigNumber.from(10000),
                 Utils.getTimeStamp(),
                 exchange_user_id,
                 exchange_id

--- a/test/service/Storage.test.ts
+++ b/test/service/Storage.test.ts
@@ -1,4 +1,5 @@
 import * as assert from "assert";
+import { BigNumber } from "ethers";
 import path from "path";
 import { Block, Hash, Transaction } from "rollup-pm-sdk";
 import { Config } from "../../src/service/common/Config";
@@ -11,7 +12,7 @@ describe("Test of Storage", () => {
             "123456789",
             "0x064c9Fc53d5936792845ca58778a52317fCf47F2",
             "0",
-            BigInt(123),
+            BigNumber.from(123),
             1668044556,
             "997DE626B2D417F0361D61C09EB907A57226DB5B",
             "a5c19fed89739383",
@@ -24,7 +25,7 @@ describe("Test of Storage", () => {
             "987654321",
             "0x064c9Fc53d5936792845ca58778a52317fCf47F2",
             "0",
-            BigInt(321),
+            BigNumber.from(321),
             1313456756,
             "997DE626B2D417F0361D61C09EB907A57226DB5B",
             "a5c19fed89739383",


### PR DESCRIPTION
트랜잭션의 amount 가 bigint로 되어 있는데, 소수점 이하 18째 까지 표현하기 위해서는 bigint로는 불가하기 때문에
ethers 의 BigNumber로 변환합니다.