### PR TITLE
[Fix] Replace with `host` with `hostname`

### DIFF
--- a/src/modules/network/IPFSManager.ts
+++ b/src/modules/network/IPFSManager.ts
@@ -30,7 +30,7 @@ export class IPFSManager {
      */
     constructor(api_url: string) {
         const uri = URI(api_url);
-        this.ipfs = new IPFS({ host: uri.host(), port: uri.port(), protocol: uri.protocol() });
+        this.ipfs = new IPFS({ host: uri.hostname(), port: uri.port(), protocol: uri.protocol() });
         this.test = false;
     }
 


### PR DESCRIPTION
host()를 호출하면 포트가 포함된 값을 전달해 주기 때문에 hostname으로 변경합니다